### PR TITLE
perf: Use String::Builder to improve render times

### DIFF
--- a/src/blueprint/html.cr
+++ b/src/blueprint/html.cr
@@ -10,7 +10,7 @@ require "./html/svg"
 require "./html/utils"
 
 module Blueprint::HTML
-  @buffer = IO::Memory.new
+  @buffer = String::Builder.new
 
   def to_html : String
     return "" unless render?

--- a/src/blueprint/html/content_capture.cr
+++ b/src/blueprint/html/content_capture.cr
@@ -1,8 +1,8 @@
 module Blueprint::HTML
   private def capture_content(&) : Nil
-    buffer_size_before_block_evaluation = @buffer.size
+    buffer_size_before_block_evaluation = @buffer.bytesize
     content = with self yield
-    if buffer_size_before_block_evaluation == @buffer.size
+    if buffer_size_before_block_evaluation == @buffer.bytesize
       ::HTML.escape(content.to_s, @buffer)
     end
   end

--- a/src/blueprint/html/renderer.cr
+++ b/src/blueprint/html/renderer.cr
@@ -10,14 +10,14 @@ module Blueprint::HTML
     end
   end
 
-  protected def render_to(buffer : IO::Memory) : Nil
+  protected def render_to(buffer : String::Builder) : Nil
     return unless render?
 
     @buffer = buffer
     blueprint
   end
 
-  protected def render_to(buffer : IO::Memory, &) : Nil
+  protected def render_to(buffer : String::Builder, &) : Nil
     return unless render?
 
     @buffer = buffer


### PR DESCRIPTION
Improves render times in 15%

```
String::Builder 364.46k (  2.74µs) (± 0.52%)  7.95kB/op  fastest
     IO::Memory 317.83k (  3.15µs) (± 0.76%)  8.99kB/op  1.15× slower
```