### PR TITLE
fix: Remove some utils methods (plain(&), comment(&), unsafe_raw(&))

### DIFF
--- a/spec/blueprint/html/safety_spec.cr
+++ b/spec/blueprint/html/safety_spec.cr
@@ -11,8 +11,7 @@ private class Example
     plain "<script>alert('Plain Text')</script>"
     render(ExampleComponent.new) { "<script>alert('ExampleComponent')</script>" }
     div(class: "some-class\" onblur=\"alert('Attribute')")
-    comment { "--><script>alert('Plain Text')</script><!--" }
-    comment "--><script>alert('Another plain text')</script><!--"
+    comment "--><script>alert('Comment')</script><!--"
     v_btn "<script>alert('content')</script>"
     v_btn(class: "some-class\" onclick=\"alert('Attribute')") { "<script>alert('hello')</script>" }
   end
@@ -72,19 +71,10 @@ describe "safety" do
     page.to_s.should contain(expected_html)
   end
 
-  it "escapes comment content passed via block" do
+  it "escapes comment content" do
     page = Example.new
     expected_html = normalize_html <<-HTML
-      <!----&gt;&lt;script&gt;alert(&#39;Plain Text&#39;)&lt;/script&gt;&lt;!---->
-    HTML
-
-    page.to_s.should contain(expected_html)
-  end
-
-  it "escapes comment content passed via argument" do
-    page = Example.new
-    expected_html = normalize_html <<-HTML
-      <!----&gt;&lt;script&gt;alert(&#39;Another plain text&#39;)&lt;/script&gt;&lt;!---->
+      <!----&gt;&lt;script&gt;alert(&#39;Comment&#39;)&lt;/script&gt;&lt;!---->
     HTML
 
     page.to_s.should contain(expected_html)

--- a/spec/blueprint/html/utils_spec.cr
+++ b/spec/blueprint/html/utils_spec.cr
@@ -10,32 +10,24 @@ private class ExamplePage
       b "World"
     end
 
-    span { plain { "Plain!" } }
-
     i "Hi"
     whitespace
     plain "User"
 
-    comment { "This is an html comment" }
-    comment "This is another html comment"
+    comment "This is an html comment"
 
-    unsafe_raw "<script>Dangerous script</script>"
-    div { unsafe_raw { "<script>Another dangerous script</script>" } }
+    div do
+      unsafe_raw "<script>Dangerous script</script>"
+    end
   end
 end
 
 describe "utils" do
   describe "#plain" do
-    it "renders plain text passed via argument" do
+    it "renders plain text" do
       page = ExamplePage.new
 
       page.to_s.should contain("<div>Hello<b>World</b></div>")
-    end
-
-    it "renders plain text passed via block" do
-      page = ExamplePage.new
-
-      page.to_s.should contain("<span>Plain!</span>")
     end
   end
 
@@ -48,16 +40,10 @@ describe "utils" do
   end
 
   describe "#comment" do
-    it "renders an html comment passed via block" do
+    it "renders an html comment" do
       page = ExamplePage.new
 
       page.to_s.should contain("<!--This is an html comment-->")
-    end
-
-    it "renders an html comment passed via argument" do
-      page = ExamplePage.new
-
-      page.to_s.should contain("<!--This is another html comment-->")
     end
   end
 
@@ -70,16 +56,10 @@ describe "utils" do
   end
 
   describe "#unsafe_raw" do
-    it "renders content passed via argument without escaping" do
+    it "renders content without escaping" do
       page = ExamplePage.new
 
       page.to_s.should contain("<script>Dangerous script</script>")
-    end
-
-    it "renders content passed via block without escaping" do
-      page = ExamplePage.new
-
-      page.to_s.should contain("<div><script>Another dangerous script</script></div>")
     end
   end
 end

--- a/src/blueprint/html/utils.cr
+++ b/src/blueprint/html/utils.cr
@@ -1,10 +1,6 @@
 module Blueprint::HTML::Utils
   private def plain(content : String) : Nil
-    plain { content }
-  end
-
-  private def plain(&) : Nil
-    ::HTML.escape(yield, @buffer)
+    ::HTML.escape(content, @buffer)
   end
 
   private def doctype : Nil
@@ -12,12 +8,8 @@ module Blueprint::HTML::Utils
   end
 
   private def comment(content : String) : Nil
-    comment { content }
-  end
-
-  private def comment(&) : Nil
     @buffer << "<!--"
-    ::HTML.escape(yield, @buffer)
+    ::HTML.escape(content, @buffer)
     @buffer << "-->"
   end
 
@@ -26,10 +18,6 @@ module Blueprint::HTML::Utils
   end
 
   def unsafe_raw(content : String) : Nil
-    unsafe_raw { content }
-  end
-
-  def unsafe_raw(&) : Nil
-    @buffer << yield
+    @buffer << content
   end
 end


### PR DESCRIPTION
Accepting block for these methods (plain(&), comment(&), unsafe_raw(&)) can lead to unexpected behaviors, eg.

```crystal
plain do
  h1 { "Hello" }
end

# or

unsafe_raw do
  div { "<script></script>" }
end
```

These method works but do not produce the expected result.