### PR TITLE
perf: Improve performance when rendering elements

### DIFF
--- a/src/blueprint/html/element_registrar.cr
+++ b/src/blueprint/html/element_registrar.cr
@@ -3,15 +3,25 @@ module Blueprint::HTML::ElementRegistrar
     {% tag ||= method_name.tr("_", "-") %}
 
     private def {{method_name.id}}(**attributes, &block) : Nil
-      element({{tag}}, **attributes) { yield }
+      @buffer << "<{{tag.id}}"
+      append_attributes(attributes)
+      @buffer << ">"
+      capture_content { yield }
+      @buffer << "</{{tag.id}}>"
     end
 
     private def {{method_name.id}}(**attributes) : Nil
-      element({{tag}}, "", **attributes)
+      @buffer << "<{{tag.id}}"
+      append_attributes(attributes)
+      @buffer << "></{{tag.id}}>"
     end
 
     private def {{method_name.id}}(__content__, **attributes) : Nil
-      element({{tag}}, __content__, **attributes)
+      @buffer << "<{{tag.id}}"
+      append_attributes(attributes)
+      @buffer << ">"
+      append_to_buffer(__content__)
+      @buffer << "</{{tag.id}}>"
     end
   end
 
@@ -19,7 +29,9 @@ module Blueprint::HTML::ElementRegistrar
     {% tag ||= method_name.tr("_", "-") %}
 
     private def {{method_name.id}}(**attributes) : Nil
-      element({{tag}}, "", **attributes)
+      @buffer << "<{{tag.id}}"
+      append_attributes(attributes)
+      @buffer << "></{{tag.id}}>"
     end
   end
 
@@ -27,7 +39,9 @@ module Blueprint::HTML::ElementRegistrar
     {% tag ||= method_name.tr("_", "-") %}
 
     private def {{method_name.id}}(**attributes) : Nil
-      void_element({{tag}}, **attributes)
+      @buffer << "<{{tag.id}}"
+      append_attributes(attributes)
+      @buffer << ">"
     end
   end
 end


### PR DESCRIPTION
~28% faster.

Before:
```
Blueprint::HTML 0.11.0 749.34k (  1.33µs) (± 0.89%)  2.69kB/op   8.22× slower
                   ECR   6.16M (162.43ns) (± 0.67%)  1.51kB/op        fastest
```

After:
```
Blueprint::HTML 0.11.0 952.75k (  1.05µs) (± 0.56%)  2.69kB/op   6.47× slower
                   ECR   6.16M (162.24ns) (± 0.83%)  1.51kB/op        fastest
```