### PR TITLE
feat: Remove #tokens helper

### DIFF
--- a/spec/blueprint/html/helpers_spec.cr
+++ b/spec/blueprint/html/helpers_spec.cr
@@ -1,44 +1,14 @@
 require "../../spec_helper"
 
-private class ExamplePage
-  include Blueprint::HTML
-
-  private def blueprint
-    div("Tokens", class: ["a", "b", tokens(c?: "c", d?: "d", e?: "e")])
-
-    div(onclick: safe("<script>Attribute script</script>")) { safe("<script>Good Script</script>") }
-
-    span safe("<script>Another Good Script</script>")
-  end
-
-  private def c?
-    true
-  end
-
-  private def d?
-    false
-  end
-
-  private def e?
-    true
-  end
-end
-
 describe "helpers" do
-  describe "#tokens" do
-    it "returns conditional classes" do
-      page = ExamplePage.new
-      expected_html = normalize_html <<-HTML
-        <div class="a b c e">Tokens</div>
-      HTML
-
-      page.to_s.should contain expected_html
-    end
-  end
-
   describe "#safe" do
     it "returns an object that Blueprint will understand as safe to render without escaping" do
-      page = ExamplePage.new
+      actual_html = Blueprint::HTML.build do
+        div(onclick: safe("<script>Attribute script</script>")) { safe("<script>Good Script</script>") }
+
+        span safe("<script>Another Good Script</script>")
+      end
+
       expected_html = normalize_html <<-HTML
         <div onclick="<script>Attribute script</script>">
           <script>Good Script</script>
@@ -49,7 +19,7 @@ describe "helpers" do
         </span>
       HTML
 
-      page.to_s.should contain expected_html
+      actual_html.should eq expected_html
     end
   end
 

--- a/src/blueprint/html/helpers.cr
+++ b/src/blueprint/html/helpers.cr
@@ -14,16 +14,4 @@ module Blueprint::HTML::Helpers
   private def escape_once(value) : SafeValue
     escape_once(value.to_s)
   end
-
-  @[Experimental]
-  macro tokens(**conditions)
-    String.build do |io|
-      {% for key, value in conditions %}
-        if {{key.id}}
-          io << " " unless io.empty?
-          io << {{value}}
-        end
-      {% end %}
-    end
-  end
 end


### PR DESCRIPTION
Remove #tokens helper. You can replace it with plain Crystal
```crystal
div class: tokens("x", outline?: "is-admin")

div class: ["x", ("is-admin" if outline?)]
```

