### PR TITLE
refactor: Enforce String type to #plain argument

### DIFF
--- a/spec/blueprint/html/utils_spec.cr
+++ b/spec/blueprint/html/utils_spec.cr
@@ -10,8 +10,6 @@ private class ExamplePage
       b "World"
     end
 
-    plain MarkdownLink.new("Blueprint", "blueprint.example.com")
-
     i "Hi"
     whitespace
     plain "User"
@@ -31,12 +29,6 @@ describe "utils" do
       page = ExamplePage.new
 
       page.to_s.should contain("<div>Hello<b>World</b></div>")
-    end
-
-    it "accepts any objects that respond `#to_s`" do
-      page = ExamplePage.new
-
-      page.to_s.should contain("[Blueprint](blueprint.example.com)")
     end
   end
 

--- a/src/blueprint/html/utils.cr
+++ b/src/blueprint/html/utils.cr
@@ -1,5 +1,5 @@
 module Blueprint::HTML::Utils
-  private def plain(content) : Nil
+  private def plain(content : String) : Nil
     append_to_buffer(content)
   end
 


### PR DESCRIPTION
Revert partially https://github.com/stephannv/blueprint/pull/78.

plain now accepts only String, but it will be added a new `render` method to render other types, eg.
```crystal
render MarkdownLink.new("Example", "example.com")
# instead of
plain MarkdownLink.new("Example", "example.com")
```