### PR TITLE
Remove tag positional content argument

### DIFF
--- a/benchmark/blueprint_html.cr
+++ b/benchmark/blueprint_html.cr
@@ -8,7 +8,7 @@ class BlueprintHTML::LayoutComponent
   def blueprint(&)
     html do
       head do
-        title @title
+        title { @title }
         meta name: "viewport", content: "width=device-width,initial-scale=1"
         link href: "/assets/tailwind.css", rel: "stylesheet"
       end
@@ -16,9 +16,15 @@ class BlueprintHTML::LayoutComponent
       body class: "bg-zinc-100" do
         nav class: "p-5", id: "main_nav" do
           ul do
-            li(class: "p-5") { a("Home", href: "/") }
-            li(class: "p-5") { a("About", href: "/about") }
-            li(class: "p-5") { a("Contact", href: "/contact") }
+            li(class: "p-5") do
+              a(href: "/") { "Home" }
+            end
+            li(class: "p-5") do
+              a(href: "/about") { "About" }
+            end
+            li(class: "p-5") do
+              a(href: "/contact") { "Contact" }
+            end
           end
         end
 
@@ -35,28 +41,28 @@ class BlueprintHTML::Page
 
   def blueprint
     render BlueprintHTML::LayoutComponent.new do
-      h1 "Hi"
+      h1 { "Hi" }
 
       table id: "test", class: "a b c d e f g" do
         tr do
           td id: "test", class: "a b c d e f g" do
-            span "Hi"
+            span { "Hi" }
           end
 
           td id: "test", class: "a b c d e f g" do
-            span "Hi"
+            span { "Hi" }
           end
 
           td id: "test", class: "a b c d e f g" do
-            span "Hi"
+            span { "Hi" }
           end
 
           td id: "test", class: "a b c d e f g" do
-            span "Hi"
+            span { "Hi" }
           end
 
           td id: "test", class: "a b c d e f g" do
-            span "Hi"
+            span { "Hi" }
           end
         end
       end

--- a/spec/blueprint/html/attributes_handling_spec.cr
+++ b/spec/blueprint/html/attributes_handling_spec.cr
@@ -3,7 +3,9 @@ require "../../spec_helper"
 describe "attributes handling" do
   it "parses normal attributes" do
     actual_html = Blueprint::HTML.build do
-      div "Blueprint", class: "hello", id: "first"
+      div class: "hello", id: "first" do
+        "Blueprint"
+      end
     end
 
     expected_html = normalize_html <<-HTML
@@ -29,7 +31,9 @@ describe "attributes handling" do
 
   it "replaces `_` by `-` on attribute names" do
     actual_html = Blueprint::HTML.build do
-      section "Blueprint", v_model: "user.name", "@click": "doSomething"
+      section v_model: "user.name", "@click": "doSomething" do
+        "Blueprint"
+      end
     end
 
     expected_html = normalize_html <<-HTML
@@ -53,7 +57,9 @@ describe "attributes handling" do
 
   it "expands NamedTuple attributes" do
     actual_html = Blueprint::HTML.build do
-      nav "Blueprint", aria: {target: "#home", selected: "false", enabled: true, hidden: false}
+      nav aria: {target: "#home", selected: "false", enabled: true, hidden: false} do
+        "Blueprint"
+      end
     end
 
     expected_html = normalize_html <<-HTML
@@ -65,7 +71,9 @@ describe "attributes handling" do
 
   it "flattens, compacts and joins array attributes" do
     actual_html = Blueprint::HTML.build do
-      div "Blueprint", class: ["a", nil, "b", ["c", nil, "d"]]
+      div class: ["a", nil, "b", ["c", nil, "d"]] do
+        "Blueprint"
+      end
     end
 
     expected_html = normalize_html <<-HTML

--- a/spec/blueprint/html/component_rendering_spec.cr
+++ b/spec/blueprint/html/component_rendering_spec.cr
@@ -7,13 +7,13 @@ private class ExamplePage
     render BasicComponent.new
 
     render ContentComponent.new do
-      span "Passing content to component"
+      span { "Passing content to component" }
     end
 
     render ComplexComponent.new do |card|
       card.title { "My card" }
       card.body { "Card content" }
-      footer "Footer tag"
+      footer { "Footer tag" }
     end
   end
 end
@@ -22,7 +22,7 @@ private class BasicComponent
   include Blueprint::HTML
 
   private def blueprint
-    header "Basic component"
+    header { "Basic component" }
   end
 end
 

--- a/spec/blueprint/html/components_registration_spec.cr
+++ b/spec/blueprint/html/components_registration_spec.cr
@@ -36,7 +36,7 @@ private class ComponentWithoutBlock
   include Blueprint::HTML
 
   private def blueprint
-    h1 "Component without block"
+    h1 { "Component without block" }
   end
 end
 

--- a/spec/blueprint/html/conditional_rendering_spec.cr
+++ b/spec/blueprint/html/conditional_rendering_spec.cr
@@ -15,7 +15,7 @@ private class NoRenderPage
   include Blueprint::HTML
 
   private def blueprint
-    h1 "This page will not be rendered"
+    h1 { "This page will not be rendered" }
   end
 
   private def blueprint(&)
@@ -31,7 +31,7 @@ private class NoRenderComponent
   include Blueprint::HTML
 
   private def blueprint
-    h1 "This component will not be rendered"
+    h1 { "This component will not be rendered" }
   end
 
   private def blueprint(&)

--- a/spec/blueprint/html/custom_elements_registration_spec.cr
+++ b/spec/blueprint/html/custom_elements_registration_spec.cr
@@ -9,7 +9,6 @@ private class ExamplePage
   private def blueprint
     div do
       v_btn(href: "#home", data: {id: 12, visible: true, disabled: false}) { "Home" }
-      v_btn("Contact", href: "#contact")
       v_btn
       card
     end
@@ -21,15 +20,6 @@ describe "custom elements registration" do
     page = ExamplePage.new
     expected_html = normalize_html <<-HTML
       <v-btn href="#home" data-id="12" data-visible>Home</v-btn>
-    HTML
-
-    page.to_s.should contain expected_html
-  end
-
-  it "allows passing content as first argument" do
-    page = ExamplePage.new
-    expected_html = normalize_html <<-HTML
-      <v-btn href="#contact">Contact</v-btn>
     HTML
 
     page.to_s.should contain expected_html

--- a/spec/blueprint/html/helpers_spec.cr
+++ b/spec/blueprint/html/helpers_spec.cr
@@ -6,7 +6,7 @@ describe "helpers" do
       actual_html = Blueprint::HTML.build do
         div(onclick: safe("<script>Attribute script</script>")) { safe("<script>Good Script</script>") }
 
-        span safe("<script>Another Good Script</script>")
+        span { safe("<script>Another Good Script</script>") }
       end
 
       expected_html = normalize_html <<-HTML
@@ -26,9 +26,9 @@ describe "helpers" do
   describe "#escape_once" do
     it "escapes HTML without affecting existing escaped entities" do
       actual_html = Blueprint::HTML.build do
-        span escape_once("&lt;&lt; Accept & Checkout")
+        span { escape_once("&lt;&lt; Accept & Checkout") }
 
-        div escape_once(MarkdownLink.new("1 < 2 &amp; 3", "example.com"))
+        div { escape_once(MarkdownLink.new("1 < 2 &amp; 3", "example.com")) }
       end
 
       expected_html = normalize_html <<-HTML
@@ -42,7 +42,7 @@ describe "helpers" do
 
     it "escapes unsafe content" do
       actual_html = Blueprint::HTML.build do
-        span escape_once("<script>alert('content')</script>")
+        span { escape_once("<script>alert('content')</script>") }
       end
 
       expected_html = normalize_html <<-HTML

--- a/spec/blueprint/html/hooks_spec.cr
+++ b/spec/blueprint/html/hooks_spec.cr
@@ -26,7 +26,7 @@ private class ExampleWithoutBlock
   include Blueprint::HTML
 
   private def blueprint
-    h1 "Without block"
+    h1 { "Without block" }
   end
 
   private def before_render(&)

--- a/spec/blueprint/html/html_build_spec.cr
+++ b/spec/blueprint/html/html_build_spec.cr
@@ -4,10 +4,10 @@ describe "html build" do
   describe ".build" do
     it "renders given html structure" do
       actual_html = Blueprint::HTML.build do
-        h1 "Hello"
+        h1 { "Hello" }
 
         div do
-          span "World"
+          span { "World" }
         end
       end
 

--- a/spec/blueprint/html/safety_spec.cr
+++ b/spec/blueprint/html/safety_spec.cr
@@ -7,12 +7,10 @@ private class Example
 
   private def blueprint
     span { "<script>alert('hello')</script>" }
-    span "<script>alert('content')</script>"
     plain "<script>alert('Plain Text')</script>"
     render(ExampleComponent.new) { "<script>alert('ExampleComponent')</script>" }
     div(class: "some-class\" onblur=\"alert('Attribute')")
     comment "--><script>alert('Comment')</script><!--"
-    v_btn "<script>alert('content')</script>"
     v_btn(class: "some-class\" onclick=\"alert('Attribute')") { "<script>alert('hello')</script>" }
   end
 end
@@ -26,19 +24,10 @@ private class ExampleComponent
 end
 
 describe "safety" do
-  it "escapes content passed to tags via block" do
+  it "escapes tag content" do
     page = Example.new
     expected_html = normalize_html <<-HTML
       <span>&lt;script&gt;alert(&#39;hello&#39;)&lt;/script&gt;</span>
-    HTML
-
-    page.to_s.should contain(expected_html)
-  end
-
-  it "escapes content passed to tags via argument" do
-    page = Example.new
-    expected_html = normalize_html <<-HTML
-      <span>&lt;script&gt;alert(&#39;content&#39;)&lt;/script&gt;</span>
     HTML
 
     page.to_s.should contain(expected_html)
@@ -80,16 +69,7 @@ describe "safety" do
     page.to_s.should contain(expected_html)
   end
 
-  it "escapes custom tag content passed via argument" do
-    page = Example.new
-    expected_html = normalize_html <<-HTML
-      <v-btn>&lt;script&gt;alert(&#39;content&#39;)&lt;/script&gt;</v-btn>
-    HTML
-
-    page.to_s.should contain(expected_html)
-  end
-
-  it "escapes custom tag content passed via block" do
+  it "escapes custom tag content" do
     page = Example.new
     expected_html = normalize_html <<-HTML
       <v-btn class="some-class&quot; onclick=&quot;alert('Attribute')">&lt;script&gt;alert(&#39;hello&#39;)&lt;/script&gt;</v-btn>

--- a/spec/blueprint/html/standard_elements_spec.cr
+++ b/spec/blueprint/html/standard_elements_spec.cr
@@ -18,8 +18,6 @@ private class ExamplePage
       {{element.id}}
       {{element.id}}(attribute: "test")
       {{element.id}} { "content" }
-      {{element.id}}("content")
-      {{element.id}}("content", attribute: "test")
       {{element.id}}(attribute: "test") { "content" }
     {% end %}
 
@@ -36,8 +34,6 @@ private class ExamplePage
     select_tag
     select_tag(attribute: "test")
     select_tag { "content" }
-    select_tag("content")
-    select_tag("content", attribute: "test")
     select_tag(attribute: "test") { "content" }
   end
 end
@@ -50,8 +46,6 @@ describe "standard HTML elements" do
         io << "<" << tag << ">" << "</" << tag << ">"
         io << "<" << tag << " attribute=\"test\">" << "</" << tag << ">"
         io << "<" << tag << ">content" << "</" << tag << ">"
-        io << "<" << tag << ">content" << "</" << tag << ">"
-        io << "<" << tag << " attribute=\"test\">content" << "</" << tag << ">"
         io << "<" << tag << " attribute=\"test\">content" << "</" << tag << ">"
       end
 
@@ -68,8 +62,6 @@ describe "standard HTML elements" do
       io << "<select></select>"
       io << "<select attribute=\"test\"></select>"
       io << "<select>content</select>"
-      io << "<select>content</select>"
-      io << "<select attribute=\"test\">content</select>"
       io << "<select attribute=\"test\">content</select>"
     end
 

--- a/spec/blueprint/html/utils_spec.cr
+++ b/spec/blueprint/html/utils_spec.cr
@@ -7,10 +7,10 @@ private class ExamplePage
     doctype
     div do
       plain "Hello"
-      b "World"
+      b { "World" }
     end
 
-    i "Hi"
+    i { "Hi" }
     whitespace
     plain "User"
 

--- a/spec/blueprint/html_spec.cr
+++ b/spec/blueprint/html_spec.cr
@@ -8,7 +8,7 @@ private class BaseLayout
 
     html lang: "en" do
       head do
-        title "Test page"
+        title { "Test page" }
 
         meta charset: "utf-8"
         meta name: "viewport", content: "width=device-width,initial-scale=1"
@@ -30,9 +30,17 @@ private class NavbarComponent
   private def blueprint
     nav do
       ul do
-        li { a("Home", href: "/home") }
-        li { a("About", href: "/about") }
-        li { a("Contact", href: "/contact") }
+        li do
+          a(href: "/home") { "Home" }
+        end
+
+        li do
+          a(href: "/about") { "About" }
+        end
+
+        li do
+          a(href: "/contact") { "Contact" }
+        end
       end
     end
   end
@@ -51,7 +59,9 @@ private class ArticleComponent
   end
 
   def title
-    div @title, class: "p-2 text-lg font-bold"
+    div class: "p-2 text-lg font-bold" do
+      @title
+    end
   end
 
   def body(&)

--- a/src/blueprint/html/element_registrar.cr
+++ b/src/blueprint/html/element_registrar.cr
@@ -15,14 +15,6 @@ module Blueprint::HTML::ElementRegistrar
       __append_attributes__(attributes)
       @buffer << "></{{tag.id}}>"
     end
-
-    private def {{method_name.id}}(__content__, **attributes) : Nil
-      @buffer << "<{{tag.id}}"
-      __append_attributes__(attributes)
-      @buffer << ">"
-      __append_to_buffer__(__content__)
-      @buffer << "</{{tag.id}}>"
-    end
   end
 
   macro register_empty_element(method_name, tag = nil)


### PR DESCRIPTION
I'm not sure if it was a good idea to accept content via positional args, so I'm removing it before 1.0.