### PR TITLE
Add attribute caching

### DIFF
--- a/benchmark/benchmark.cr
+++ b/benchmark/benchmark.cr
@@ -1,16 +1,19 @@
 require "benchmark"
 
 require "./blueprint_html"
+require "./cached_blueprint_html"
 require "./ecr"
 
 require "../src/blueprint/version"
 
 blueprint_html = BlueprintHTML::Page.new.to_s
+cached_blueprint_html = BlueprintHTML::PageWithCache.new.to_s
 ecr = ECR::Page.new.to_s.chomp # ECR is here just to have a base value to compare
 
-raise "Different results" if blueprint_html != ecr
+raise "Different results" if blueprint_html != ecr || blueprint_html != cached_blueprint_html
 
 Benchmark.ips do |x|
-  x.report("Blueprint::HTML #{Blueprint::VERSION}") { BlueprintHTML::Page.new.to_s }
   x.report("ECR") { ECR::Page.new.to_s }
+  x.report("Cached Blueprint::HTML #{Blueprint::VERSION}") { BlueprintHTML::PageWithCache.new.to_s }
+  x.report("Blueprint::HTML #{Blueprint::VERSION}") { BlueprintHTML::Page.new.to_s }
 end

--- a/benchmark/cached_blueprint_html.cr
+++ b/benchmark/cached_blueprint_html.cr
@@ -1,0 +1,73 @@
+require "../src/blueprint/html"
+
+class BlueprintHTML::LayoutComponentWithCache
+  include Blueprint::HTML
+  include Blueprint::HTML::AttributeCaching
+
+  def initialize(@title = "Example"); end
+
+  def blueprint(&)
+    html do
+      head do
+        title { @title }
+        meta name: "viewport", content: "width=device-width,initial-scale=1"
+        link href: "/assets/tailwind.css", rel: "stylesheet"
+      end
+
+      body class: "bg-zinc-100" do
+        nav class: "p-5", id: "main_nav" do
+          ul do
+            li(class: "p-5") do
+              a(href: "/") { "Home" }
+            end
+            li(class: "p-5") do
+              a(href: "/about") { "About" }
+            end
+            li(class: "p-5") do
+              a(href: "/contact") { "Contact" }
+            end
+          end
+        end
+
+        div class: "container mx-auto p-5" do
+          yield
+        end
+      end
+    end
+  end
+end
+
+class BlueprintHTML::PageWithCache
+  include Blueprint::HTML
+  include Blueprint::HTML::AttributeCaching
+
+  def blueprint
+    render BlueprintHTML::LayoutComponentWithCache.new do
+      h1 { "Hi" }
+
+      table id: "test", class: "a b c d e f g" do
+        tr do
+          td id: "test", class: "a b c d e f g" do
+            span { "Hi" }
+          end
+
+          td id: "test", class: "a b c d e f g" do
+            span { "Hi" }
+          end
+
+          td id: "test", class: "a b c d e f g" do
+            span { "Hi" }
+          end
+
+          td id: "test", class: "a b c d e f g" do
+            span { "Hi" }
+          end
+
+          td id: "test", class: "a b c d e f g" do
+            span { "Hi" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/blueprint/html/attribute_caching_spec.cr
+++ b/spec/blueprint/html/attribute_caching_spec.cr
@@ -1,0 +1,36 @@
+require "../../spec_helper"
+
+private class PageWithAttributeCaching
+  include Blueprint::HTML
+  include Blueprint::HTML::AttributeCaching
+
+  private def blueprint
+    ul id: "my-list" do
+      li class: ["a", "b", "c"], data: {a: 1, b: true, c: false, d: :symbol, e: "string"} do
+        a href: "<script>alert('unsafe')</script>" do
+          "hello"
+        end
+      end
+    end
+  end
+end
+
+private class Page
+  include Blueprint::HTML
+
+  private def blueprint
+    ul id: "my-list" do
+      li class: ["a", "b", "c"], data: {a: 1, b: true, c: false, d: :symbol, e: "string"} do
+        a href: "<script>alert('unsafe')</script>" do
+          "hello"
+        end
+      end
+    end
+  end
+end
+
+describe "attributes caching" do
+  it "outputs the html correctly" do
+    Page.new.to_s.should eq PageWithAttributeCaching.new.to_s
+  end
+end

--- a/src/blueprint/html.cr
+++ b/src/blueprint/html.cr
@@ -76,4 +76,10 @@ module Blueprint::HTML
   private def render? : Bool
     true
   end
+
+  private def buffering_to(other : String::Builder, &) : Nil
+    original, @buffer = @buffer, other
+    yield
+    @buffer = original
+  end
 end

--- a/src/blueprint/html/attribute_caching.cr
+++ b/src/blueprint/html/attribute_caching.cr
@@ -1,0 +1,18 @@
+@[Experimental]
+module Blueprint::HTML::AttributeCaching
+  private CACHE = {} of UInt64 => String
+
+  private def __append_attributes__(attributes : NamedTuple) : Nil
+    return if attributes.empty?
+
+    attributes_hash : UInt64 = attributes.hash
+
+    if cached_attributes = CACHE[attributes_hash]?
+      @buffer << cached_attributes
+    else
+      new_buffer = String::Builder.new
+      buffering_to(new_buffer) { super }
+      @buffer << (CACHE[attributes_hash] = new_buffer.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Adding experimental attribute caching that improve performance by 50% compared to previous version.
``` 
NEW Blueprint::HTML   1.39M (721.57ns) (± 0.33%)  2.69kB/op        fastest
OLD Blueprint::HTML 919.09k (  1.09µs) (± 0.55%)  2.69kB/op   1.51× slower
```