### PR TITLE
Remove unused render block method

### DIFF
--- a/src/blueprint/html/buffer_renderer.cr
+++ b/src/blueprint/html/buffer_renderer.cr
@@ -5,10 +5,6 @@ module Blueprint::HTML::BufferRenderer
     ::HTML.escape(content, buffer)
   end
 
-  def render(content : Proc, to buffer : String::Builder) : Nil
-    BlockRenderer.render(content, to: buffer)
-  end
-
   def render(content : SafeObject, to buffer : String::Builder) : Nil
     content.to_s(buffer)
   end


### PR DESCRIPTION
This method is redundant to `render(block : Proc, to buffer : String::Builder) : Nil`, and `BlockRenderer` was removed a while ago.